### PR TITLE
Corrected selection of hid.c on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(include ${LIBUSB_1_INCLUDE_DIRS})
 
 set(SOURCE_FILES main.cpp skylander.cpp include/skylander.h portalio.cpp include/portalio.h include/hidapi.h)
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
     set(SOURCE_FILES ${SOURCE_FILES} hid_linux.c)
     set(SL_LIBS ${LIBUSB_1_LIBRARIES} pthread)
 elseif(MINGW)
@@ -22,7 +22,7 @@ elseif(APPLE)
     set(SL_LIBS ${LIBUSB_1_LIBRARIES} "-framework CoreFoundation" "-framework IOKit")
 else(UNIX)
     message(FATAL_ERROR "Not supported platform")
-endif(UNIX)
+endif(UNIX AND NOT APPLE)
 
 add_executable(SkyDumper ${SOURCE_FILES})
 target_link_libraries(SkyDumper ${SL_LIBS})


### PR DESCRIPTION
This avoids hid_linux.c being selected for use on OSX machines. OSX evaluates as true in the "if (UNIX)" condition and we never got to the "else (APPLE)" in the CMakeLists.txt file. This corrects that.